### PR TITLE
when submitting the pos with redeem points then need a validation if …

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -736,6 +736,19 @@ export default {
       evntBus.$emit("set_customer_readonly", false);
     },
     submit(event, payment_received = false, print = false) {
+      let hasLoyalty = this.flt(this.loyalty_amount) > 0;
+      let hasCashPayment = this.invoice_doc.payments.some(
+        (p) => this.flt(p.amount) > 0
+      );
+
+      if (hasLoyalty && hasCashPayment) {
+        evntBus.$emit("show_mesage", {
+          text: __("You cannot use Loyalty Points together with another payment method."),
+          color: "error",
+        });
+        frappe.utils.play_sound("error");
+        return;
+      }
       if (!this.invoice_doc.is_return && this.total_payments < 0) {
         evntBus.$emit("show_mesage", {
           text: `Payments not correct`,


### PR DESCRIPTION
…any mode of payments are selected. the system shouldn’t allow submit the invoice when mode of payment and redeem points have value in it, throw a error message when trying to submit in that way. https://nexevestechnologies.atlassian.net/browse/AFT-49?atlOrigin=eyJpIjoiMjAzN2MwMDExNGQ0NGU0M2I5MjhhNDc4NWJhZDA2NzQiLCJwIjoiaiJ9